### PR TITLE
Update make_crossword.py

### DIFF
--- a/make_crossword.py
+++ b/make_crossword.py
@@ -57,7 +57,7 @@ def make_cell(col, row, color, text=None, number=None):
 
 def vertices(row, col):
     order = ((0, 0), (0, 1), (1, 1), (1, 0))
-    vertices = map (lambda (x,y): ((row + x) * size, (col + y) * size), order)
+    vertices = map (lambda x, y: ((row + x) * size, (col + y) * size), order)
     return ' '.join(["%s,%s" % vertex for vertex in vertices])
 
 def is_start_of_word(lines, i, j):


### PR DESCRIPTION
Trying to get this to work in Python 3, but it throws errors that I don't understand.  
Made the following change to the lambda function, but I still get an error (see below):   

def vertices(row, col):
    """ order is the tuple to which the map will apply the lambda function.
        The lambda function calculates a tuple of offsets based on cell sizes of 100.
        The vertices are calculated results from applying map() to the iterable order.
        The return statement joins together the tuples
    """
    order = ((0, 0), (0, 1), (1, 1), (1, 0))
    # the following code was from Python 2.  It needs to be updated for Lambda functions in Python 3    
    #    vertices = map(lambda (x,y) : ((row + x) * size, (col + y) * size), order)
    vertices = map(lambda x,y : ((row + x) * size, (col + y) * size), order)
    return ' '.join(["%s,%s" % vertex for vertex in vertices])

def vertices(row, col):
    """ order is the tuple to which the map will apply the lambda function.
        The lambda function calculates a tuple of offsets based on cell sizes of 100.
        The vertices are calculated results from applying map() to the iterable order.
        The return statement joins together the tuples
    """
    order = ((0, 0), (0, 1), (1, 1), (1, 0))
    # the following code was from Python 2.  It needs to be updated for Lambda functions in Python 3    
    #    vertices = map(lambda (x,y) : ((row + x) * size, (col + y) * size), order)
    vertices = map(lambda x,y : ((row + x) * size, (col + y) * size), order)
    return ' '.join(["%s,%s" % vertex for vertex in vertices])

I've tested it in Python 2 today and that doesn't work either.  

Someone please help.  I'd like to get this working.